### PR TITLE
build: Fix a build warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_PREREQ(2.63)
 AC_INIT([pix], [pix_version],
         [http://bugzilla.gnome.org/enter_bug.cgi?product=pix],
         [pix])
-AM_INIT_AUTOMAKE([1.11 foreign no-dist-gzip dist-xz tar-ustar])
+AM_INIT_AUTOMAKE([1.11 foreign no-dist-gzip dist-xz tar-ustar subdir-objects])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
Add subdir-objects to the AM_INIT_AUTOMAKE macro in configure.ac to quiet some build warnings