### PR TITLE
Fix issue 28

### DIFF
--- a/extensions/cairo_io/cairo-image-surface-xcf.c
+++ b/extensions/cairo_io/cairo-image-surface-xcf.c
@@ -900,8 +900,9 @@ read_pixels_from_hierarchy (GDataInputStream  *data_stream,
 	if (*error != NULL)
 		goto read_error;
 
-	if (is_gimp_channel)
-		g_assert (in_bpp == 1);
+	if (is_gimp_channel && in_bpp != 1){
+		printf("Error: in_bpp = %d and is_gimp_channel is true. Expected in_bpp = 1 when is_gimp_channel is true.\n", in_bpp);
+		goto read_error;
 
 	if (! is_gimp_channel)
 		layer->bpp = in_bpp;

--- a/extensions/cairo_io/cairo-image-surface-xcf.c
+++ b/extensions/cairo_io/cairo-image-surface-xcf.c
@@ -903,6 +903,7 @@ read_pixels_from_hierarchy (GDataInputStream  *data_stream,
 	if (is_gimp_channel && in_bpp != 1){
 		printf("Error: in_bpp = %d and is_gimp_channel is true. Expected in_bpp = 1 when is_gimp_channel is true.\n", in_bpp);
 		goto read_error;
+	}
 
 	if (! is_gimp_channel)
 		layer->bpp = in_bpp;


### PR DESCRIPTION
Print an error to standard out instead of an assert that fails and crashes Pix, fix #28 