### PR TITLE
Issue 118 Wrong date in about info

### DIFF
--- a/pix/gth-application.c
+++ b/pix/gth-application.c
@@ -398,7 +398,7 @@ gth_application_local_command_line (GApplication   *application,
 	}
 
 	if (version) {
-		g_printf ("%s %s, Copyright © 2001-2010 Free Software Foundation, Inc.\n", PACKAGE_NAME, PACKAGE_VERSION);
+		g_printf ("%s %s, Copyright © 2001-2023 Free Software Foundation, Inc.\n", PACKAGE_NAME, PACKAGE_VERSION);
 		handled_locally = TRUE;
 	}
 

--- a/pix/gth-browser-actions-callbacks.c
+++ b/pix/gth-browser-actions-callbacks.c
@@ -124,7 +124,7 @@ gth_browser_activate_about (GSimpleAction *action,
 
 	gtk_show_about_dialog (GTK_WINDOW (browser),
 			       "version", PACKAGE_VERSION,
-			       "copyright", "Copyright \xc2\xa9 2001-2020 Free Software Foundation, Inc.",
+			       "copyright", "Copyright \xc2\xa9 2001-2023 Free Software Foundation, Inc.",
 			       "comments", _("An image viewer and browser."),
 			       "authors", authors,
 			       "documenters", documenters,


### PR DESCRIPTION
gth-application.c - updates date found when you $pix -v
gth-browser-actions-callbacks.c - updates date found in the About Pix window.