### PR TITLE
Fixed build with libraw 0.21

### DIFF
--- a/extensions/raw_files/gth-metadata-provider-raw.c
+++ b/extensions/raw_files/gth-metadata-provider-raw.c
@@ -62,7 +62,7 @@ gth_metadata_provider_raw_read (GthMetadataProvider *self,
 	if (!_g_mime_type_is_raw (gth_file_data_get_mime_type (file_data)))
 		return;
 
-	raw_data = libraw_init (LIBRAW_OPIONS_NO_MEMERR_CALLBACK | LIBRAW_OPIONS_NO_DATAERR_CALLBACK);
+	raw_data = libraw_init (GTH_LIBRAW_INIT_OPTIONS);
 	if (raw_data == NULL)
 		goto fatal_error;
 

--- a/extensions/raw_files/gth-metadata-provider-raw.h
+++ b/extensions/raw_files/gth-metadata-provider-raw.h
@@ -25,6 +25,13 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <pix.h>
+#include <libraw.h>
+
+#if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 21)
+#define GTH_LIBRAW_INIT_OPTIONS (LIBRAW_OPIONS_NO_DATAERR_CALLBACK)
+#else
+#define GTH_LIBRAW_INIT_OPTIONS (LIBRAW_OPIONS_NO_MEMERR_CALLBACK | LIBRAW_OPIONS_NO_DATAERR_CALLBACK)
+#endif
 
 #define GTH_TYPE_METADATA_PROVIDER_RAW         (gth_metadata_provider_raw_get_type ())
 #define GTH_METADATA_PROVIDER_RAW(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), GTH_TYPE_METADATA_PROVIDER_RAW, GthMetadataProviderRaw))

--- a/extensions/raw_files/main.c
+++ b/extensions/raw_files/main.c
@@ -213,7 +213,7 @@ _cairo_image_surface_create_from_raw (GInputStream  *istream,
 	size_t         size;
 	GthImage      *image = NULL;
 
-	raw_data = libraw_init (LIBRAW_OPIONS_NO_MEMERR_CALLBACK | LIBRAW_OPIONS_NO_DATAERR_CALLBACK);
+	raw_data = libraw_init (GTH_LIBRAW_INIT_OPTIONS);
 	if (raw_data == NULL) {
 		_libraw_set_gerror (error, errno);
 		goto fatal_error;
@@ -300,7 +300,7 @@ _cairo_image_surface_create_from_raw (GInputStream  *istream,
 		if ((original_width != NULL) && (original_height != NULL)) {
 			libraw_close (raw_data);
 
-			raw_data = libraw_init (LIBRAW_OPIONS_NO_MEMERR_CALLBACK | LIBRAW_OPIONS_NO_DATAERR_CALLBACK);
+			raw_data = libraw_init (GTH_LIBRAW_INIT_OPTIONS);
 			if (raw_data == NULL)
 				goto fatal_error;
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/GNOME/gthumb/commit/da0d3f22a5c3a141211d943e7d963d14090011ec.

gthumb 3.12.2 does not build with libraw 0.21. Since current master is based on gthumb 3.12.2, the failure is unfortunately the same. So here is a build log of gthumb: https://hydra.nixos.org/build/209327709/nixlog/1

This *should* still work with old libraw (tested 0.20.2 and 0.21.1) since this is a conditional port.

---

`LIBRAW_OPIONS_*` (missing a `T` in `OPTIONS`) is [a typo made by libraw](https://github.com/LibRaw/LibRaw/blob/0.20.2/libraw/libraw_const.h#L546), not a gthumb issue and I am applying the gthumb patch as-is. The typo is kept in libraw [0.21](https://github.com/LibRaw/LibRaw/blob/0.21.1/libraw/libraw_const.h#L666).