### PR TITLE
Add support for exiv-0.28

### DIFF
--- a/extensions/exiv2_tools/exiv2-utils.cpp
+++ b/extensions/exiv2_tools/exiv2-utils.cpp
@@ -740,7 +740,11 @@ get_exif_default_category (const Exiv2::Exifdatum &md)
 
 
 static void
+#if EXIV2_TEST_VERSION(0,28,0)
+exiv2_read_metadata (Exiv2::Image::UniquePtr  image,
+#else
 exiv2_read_metadata (Exiv2::Image::AutoPtr  image,
+#endif
 		     GFileInfo             *info,
 		     gboolean               update_general_attributes)
 {
@@ -882,7 +886,11 @@ exiv2_read_metadata_from_file (GFile         *file,
 			return FALSE;
 		}
 
+#if EXIV2_TEST_VERSION(0,28,0)
+		Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
+#else
 		Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
+#endif
 		g_free (path);
 
 		if (image.get() == 0) {
@@ -892,9 +900,17 @@ exiv2_read_metadata_from_file (GFile         *file,
 		}
 		// Set the log level to only show errors (and suppress warnings, informational and debug messages)
 		Exiv2::LogMsg::setLevel(Exiv2::LogMsg::error);
+#if EXIV2_TEST_VERSION(0,28,0)
+		exiv2_read_metadata (std::move(image), info, update_general_attributes);
+#else
 		exiv2_read_metadata (image, info, update_general_attributes);
+#endif
 	}
+#if EXIV2_TEST_VERSION(0,28,0)
+	catch (Exiv2::Error& e) {
+#else
 	catch (Exiv2::AnyError& e) {
+#endif
 		if (error != NULL)
 			*error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_FAILED, e.what());
 		return FALSE;
@@ -913,7 +929,11 @@ exiv2_read_metadata_from_buffer (void       *buffer,
 				 GError    **error)
 {
 	try {
+#if EXIV2_TEST_VERSION(0,28,0)
+		Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open ((Exiv2::byte*) buffer, buffer_size);
+#else
 		Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open ((Exiv2::byte*) buffer, buffer_size);
+#endif
 
 		if (image.get() == 0) {
 			if (error != NULL)
@@ -921,9 +941,17 @@ exiv2_read_metadata_from_buffer (void       *buffer,
 			return FALSE;
 		}
 
+#if EXIV2_TEST_VERSION(0,28,0)
+		exiv2_read_metadata (std::move(image), info, update_general_attributes);
+#else
 		exiv2_read_metadata (image, info, update_general_attributes);
+#endif
 	}
+#if EXIV2_TEST_VERSION(0,28,0)
+	catch (Exiv2::Error& e) {
+#else
 	catch (Exiv2::AnyError& e) {
+#endif
 		if (error != NULL)
 			*error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_FAILED, e.what());
 		return FALSE;
@@ -972,7 +1000,11 @@ exiv2_read_sidecar (GFile     *file,
 		g_free (path);
 
 		std::string xmpPacket;
+#if EXIV2_TEST_VERSION(0,28,0)
+		xmpPacket.assign(reinterpret_cast<char*>(buf.data()), buf.size());
+#else
 		xmpPacket.assign(reinterpret_cast<char*>(buf.pData_), buf.size_);
+#endif
 		Exiv2::XmpData xmpData;
 
 		if (0 != Exiv2::XmpParser::decode(xmpData, xmpPacket))
@@ -1018,7 +1050,11 @@ exiv2_read_sidecar (GFile     *file,
 
 		set_attributes_from_tagsets (info, update_general_attributes);
 	}
+#if EXIV2_TEST_VERSION(0,28,0)
+	catch (Exiv2::Error& e) {
+#else
 	catch (Exiv2::AnyError& e) {
+#endif
 		std::cerr << "Caught Exiv2 exception '" << e << "'\n";
 		return FALSE;
 	}
@@ -1118,7 +1154,11 @@ dump_exif_data (Exiv2::ExifData &exifData,
 
 
 static Exiv2::DataBuf
+#if EXIV2_TEST_VERSION(0,28,0)
+exiv2_write_metadata_private (Exiv2::Image::UniquePtr  image,
+#else
 exiv2_write_metadata_private (Exiv2::Image::AutoPtr  image,
+#endif
 			      GFileInfo             *info,
 			      GthImage              *image_data)
 {
@@ -1155,13 +1195,21 @@ exiv2_write_metadata_private (Exiv2::Image::AutoPtr  image,
 			const char *value_type = gth_main_get_metadata_type (metadatum, attributes[i]);
 
 			if ((raw_value != NULL) && (strcmp (raw_value, "") != 0) && (value_type != NULL)) {
+#if EXIV2_TEST_VERSION(0,28,0)
+				Exiv2::Value::UniquePtr value = Exiv2::Value::create (Exiv2::TypeInfo::typeId (value_type));
+#else
 				Exiv2::Value::AutoPtr value = Exiv2::Value::create (Exiv2::TypeInfo::typeId (value_type));
+#endif
 				value->read (raw_value);
 				Exiv2::ExifKey exif_key(key);
 				ed.add (exif_key, value.get());
 			}
 		}
+#if EXIV2_TEST_VERSION(0,28,0)
+		catch (Exiv2::Error& e) {
+#else
 		catch (Exiv2::AnyError& e) {
+#endif
 			/* we don't care about invalid key errors */
 			g_warning ("%s", e.what());
 		}
@@ -1277,7 +1325,11 @@ exiv2_write_metadata_private (Exiv2::Image::AutoPtr  image,
 			value_type = gth_main_get_metadata_type (metadatum, attributes[i]);
 			if (value_type != NULL) {
 				/* See the exif data code above for an explanation. */
+#if EXIV2_TEST_VERSION(0,28,0)
+				Exiv2::Value::UniquePtr value = Exiv2::Value::create (Exiv2::TypeInfo::typeId (value_type));
+#else
 				Exiv2::Value::AutoPtr value = Exiv2::Value::create (Exiv2::TypeInfo::typeId (value_type));
+#endif
 				Exiv2::IptcKey iptc_key(key);
 
 				const char *raw_value;
@@ -1303,7 +1355,11 @@ exiv2_write_metadata_private (Exiv2::Image::AutoPtr  image,
 				}
 			}
 		}
+#if EXIV2_TEST_VERSION(0,28,0)
+		catch (Exiv2::Error& e) {
+#else
 		catch (Exiv2::AnyError& e) {
+#endif
 			/* we don't care about invalid key errors */
 			g_warning ("%s", e.what());
 		}
@@ -1327,7 +1383,11 @@ exiv2_write_metadata_private (Exiv2::Image::AutoPtr  image,
 			value_type = gth_main_get_metadata_type (metadatum, attributes[i]);
 			if (value_type != NULL) {
 				/* See the exif data code above for an explanation. */
+#if EXIV2_TEST_VERSION(0,28,0)
+				Exiv2::Value::UniquePtr value = Exiv2::Value::create (Exiv2::TypeInfo::typeId (value_type));
+#else
 				Exiv2::Value::AutoPtr value = Exiv2::Value::create (Exiv2::TypeInfo::typeId (value_type));
+#endif
 				Exiv2::XmpKey xmp_key(key);
 
 				const char *raw_value;
@@ -1353,7 +1413,11 @@ exiv2_write_metadata_private (Exiv2::Image::AutoPtr  image,
 				}
 			}
 		}
+#if EXIV2_TEST_VERSION(0,28,0)
+		catch (Exiv2::Error& e) {
+#else
 		catch (Exiv2::AnyError& e) {
+#endif
 			/* we don't care about invalid key errors */
 			g_warning ("%s", e.what());
 		}
@@ -1369,7 +1433,11 @@ exiv2_write_metadata_private (Exiv2::Image::AutoPtr  image,
 		image->setXmpData(xd);
 		image->writeMetadata();
 	}
+#if EXIV2_TEST_VERSION(0,28,0)
+	catch (Exiv2::Error& e) {
+#else
 	catch (Exiv2::AnyError& e) {
+#endif
 		g_warning ("%s", e.what());
 	}
 
@@ -1396,16 +1464,33 @@ exiv2_write_metadata (GthImageSaveData *data)
 {
 	if (exiv2_supports_writes (data->mime_type) && (data->file_data != NULL)) {
 		try {
+#if EXIV2_TEST_VERSION(0,28,0)
+			Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open ((Exiv2::byte*) data->buffer, data->buffer_size);
+#else
 			Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open ((Exiv2::byte*) data->buffer, data->buffer_size);
+#endif
 			g_assert (image.get() != 0);
 
+#if EXIV2_TEST_VERSION(0,28,0)
+			Exiv2::DataBuf buf = exiv2_write_metadata_private (std::move(image), data->file_data->info, data->image);
+#else
 			Exiv2::DataBuf buf = exiv2_write_metadata_private (image, data->file_data->info, data->image);
+#endif
 
 			g_free (data->buffer);
+#if EXIV2_TEST_VERSION(0,28,0)
+			data->buffer = g_memdup (buf.data(), buf.size());
+			data->buffer_size = buf.size();
+#else
 			data->buffer = g_memdup (buf.pData_, buf.size_);
 			data->buffer_size = buf.size_;
+#endif
 		}
+#if EXIV2_TEST_VERSION(0,28,0)
+		catch (Exiv2::Error& e) {
+#else
 		catch (Exiv2::AnyError& e) {
+#endif
 			if (data->error != NULL)
 				*data->error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_FAILED, e.what());
 			g_warning ("%s\n", e.what());
@@ -1426,16 +1511,33 @@ exiv2_write_metadata_to_buffer (void      **buffer,
 				GError    **error)
 {
 	try {
+#if EXIV2_TEST_VERSION(0,28,0)
+		Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open ((Exiv2::byte*) *buffer, *buffer_size);
+#else
 		Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open ((Exiv2::byte*) *buffer, *buffer_size);
+#endif
 		g_assert (image.get() != 0);
 
+#if EXIV2_TEST_VERSION(0,28,0)
+		Exiv2::DataBuf buf = exiv2_write_metadata_private (std::move(image), info, image_data);
+#else
 		Exiv2::DataBuf buf = exiv2_write_metadata_private (image, info, image_data);
+#endif
 
 		g_free (*buffer);
+#if EXIV2_TEST_VERSION(0,28,0)
+		*buffer = g_memdup (buf.data(), buf.size());
+		*buffer_size = buf.size();
+#else
 		*buffer = g_memdup (buf.pData_, buf.size_);
 		*buffer_size = buf.size_;
+#endif
 	}
+#if EXIV2_TEST_VERSION(0,28,0)
+	catch (Exiv2::Error& e) {
+#else
 	catch (Exiv2::AnyError& e) {
+#endif
 		if (error != NULL)
 			*error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_FAILED, e.what());
 		return FALSE;
@@ -1452,7 +1554,11 @@ exiv2_clear_metadata (void   **buffer,
 		      GError **error)
 {
 	try {
+#if EXIV2_TEST_VERSION(0,28,0)
+		Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open ((Exiv2::byte*) *buffer, *buffer_size);
+#else
 		Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open ((Exiv2::byte*) *buffer, *buffer_size);
+#endif
 
 		if (image.get() == 0) {
 			if (error != NULL)
@@ -1464,7 +1570,11 @@ exiv2_clear_metadata (void   **buffer,
 			image->clearMetadata();
 			image->writeMetadata();
 		}
+#if EXIV2_TEST_VERSION(0,28,0)
+		catch (Exiv2::Error& e) {
+#else
 		catch (Exiv2::AnyError& e) {
+#endif
 			g_warning ("%s", e.what());
 		}
 
@@ -1473,10 +1583,19 @@ exiv2_clear_metadata (void   **buffer,
 		Exiv2::DataBuf buf = io.read(io.size());
 
 		g_free (*buffer);
+#if EXIV2_TEST_VERSION(0,28,0)
+		*buffer = g_memdup (buf.data(), buf.size());
+		*buffer_size = buf.size();
+#else
 		*buffer = g_memdup (buf.pData_, buf.size_);
 		*buffer_size = buf.size_;
+#endif
 	}
+#if EXIV2_TEST_VERSION(0,28,0)
+	catch (Exiv2::Error& e) {
+#else
 	catch (Exiv2::AnyError& e) {
+#endif
 		if (error != NULL)
 			*error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_FAILED, e.what());
 		return FALSE;
@@ -1509,26 +1628,44 @@ exiv2_generate_thumbnail (const char *uri,
 		if (path == NULL)
 			return NULL;
 
+#if EXIV2_TEST_VERSION(0,28,0)
+		Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open (path);
+#else
 		Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open (path);
+#endif
 		image->readMetadata ();
 		Exiv2::ExifThumbC exifThumb (image->exifData ());
 		Exiv2::DataBuf thumb = exifThumb.copy ();
 
 		g_free (path);
 
+#if EXIV2_TEST_VERSION(0,28,0)
+		if (thumb.data() == NULL)
+#else
 		if (thumb.pData_ == NULL)
+#endif
 			return NULL;
 
 		Exiv2::ExifData &ed = image->exifData();
 
+#if EXIV2_TEST_VERSION(0,28,0)
+		long orientation = (ed["Exif.Image.Orientation"].count() > 0) ? ed["Exif.Image.Orientation"].toUint32() : 1;
+		long image_width = (ed["Exif.Photo.PixelXDimension"].count() > 0) ? ed["Exif.Photo.PixelXDimension"].toUint32() : -1;
+		long image_height = (ed["Exif.Photo.PixelYDimension"].count() > 0) ? ed["Exif.Photo.PixelYDimension"].toUint32() : -1;
+#else
 		long orientation = (ed["Exif.Image.Orientation"].count() > 0) ? ed["Exif.Image.Orientation"].toLong() : 1;
 		long image_width = (ed["Exif.Photo.PixelXDimension"].count() > 0) ? ed["Exif.Photo.PixelXDimension"].toLong() : -1;
 		long image_height = (ed["Exif.Photo.PixelYDimension"].count() > 0) ? ed["Exif.Photo.PixelYDimension"].toLong() : -1;
+#endif
 
 		if ((orientation != 1) || (image_width <= 0) || (image_height <= 0))
 			return NULL;
 
+#if EXIV2_TEST_VERSION(0,28,0)
+		GInputStream *stream = g_memory_input_stream_new_from_data (thumb.data(), thumb.size(), NULL);
+#else
 		GInputStream *stream = g_memory_input_stream_new_from_data (thumb.pData_, thumb.size_, NULL);
+#endif
 		pixbuf = gdk_pixbuf_new_from_stream (stream, NULL, NULL);
 		g_object_unref (stream);
 
@@ -1582,7 +1719,11 @@ exiv2_generate_thumbnail (const char *uri,
 		gdk_pixbuf_set_option (pixbuf, "orientation", orientation_s);
 		g_free (orientation_s);
 	}
+#if EXIV2_TEST_VERSION(0,28,0)
+	catch (Exiv2::Error& e) {
+#else
 	catch (Exiv2::AnyError& e) {
+#endif
 	}
 
 	return pixbuf;


### PR DESCRIPTION
exiv 0.28 just hit arch linux and causes build failures for pix.

The patch is based on this gthumb commit - https://github.com/GNOME/gthumb/commit/3376550ae109286de09ce5f89e05060eb80230a7