### PR TITLE
Automatically rotate video based on its orientation tag

### DIFF
--- a/extensions/gstreamer_tools/gth-media-viewer-page.c
+++ b/extensions/gstreamer_tools/gth-media-viewer-page.c
@@ -1378,6 +1378,13 @@ _gth_media_viewer_page_set_uri (GthMediaViewerPage *self,
 
 	gst_element_set_state (self->priv->playbin, GST_STATE_NULL);
 
+	/* Re-create videoflip every time because the auto-mode will remember
+	   the last-seen orientation tag and will happily use it for a new
+	   file that does not contain any orientation tag. */
+	GstElement *videoflip = gst_element_factory_make ("videoflip", "");
+	g_object_set (videoflip, "video-direction", GST_VIDEO_ORIENTATION_AUTO, NULL);
+	g_object_set (self->priv->playbin, "video-filter", videoflip, NULL);
+
 	g_object_set (G_OBJECT (self->priv->playbin), "uri", uri, NULL);
 	gst_element_set_state (self->priv->playbin, state);
 	wait_playbin_state_change_to_complete (self);


### PR DESCRIPTION
This adds the videoflip filter to our playbin in the auto-mode, which will automatically rotate the video based on any potential orientation tag.

I tested this with gstreamer 1.22.6 and it works fine with the vertical videos recorded by my Pixel 4a and it also works with the example posted in https://github.com/linuxmint/pix/issues/61#issuecomment-667632822.

Note that I don't have much experience with GObject, so I am not sure if this implementation is appropriate (am I leaking videoflip objects here?).